### PR TITLE
Allow passing a falsey value through `url` and still getting the default

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -3,13 +3,13 @@ import requests
 from hvac import exceptions
 
 class Client(object):
-    def __init__(self, url='http://localhost:8200', token=None, cert=None,
+    def __init__(self, url=None, token=None, cert=None,
                  verify=True):
         self._session = requests.Session()
         self._session.cert = cert
         self._session.verify = verify
 
-        self._url = url
+        self._url = url or 'http://localhost:8200'
 
         if token:
             self.auth_token(token)


### PR DESCRIPTION
This is important if you're doing something like: 

```python
Client(url=os.environ.get('VAULT_ADDR'))
```

without repeating the logic and falling back to my own default.