### PR TITLE
pypip.io is offline (expired domain) and seems to no longer be suppor…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [HashiCorp](https://hashicorp.com/) [Vault](https://www.vaultproject.io) API client for Python 2/3
 
-[![Travis CI](https://travis-ci.org/ianunruh/hvac.svg?branch=master)](https://travis-ci.org/ianunruh/hvac) [![Latest Version](https://pypip.in/version/hvac/badge.svg)](https://pypi.python.org/pypi/hvac/)
+[![Travis CI](https://travis-ci.org/ianunruh/hvac.svg?branch=master)](https://travis-ci.org/ianunruh/hvac) [![Latest Version](https://img.shields.io/pypi/v/hvac.svg)](https://pypi.python.org/pypi/hvac/)
 
 Tested against Vault v0.1.2 and HEAD. Requires v0.1.2 or later.
 


### PR DESCRIPTION
…ted. Updating with badge.io replacement badge host.

this is a really minor update, but I figured I would be a good neighbor since I merged it earlier. :)