### PR TITLE
Add is_authenticated method

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -130,6 +130,7 @@ class IntegrationTest(TestCase):
         result = self.client.auth_userpass('testuser', 'testpass')
 
         assert self.client.token == result['auth']['client_token']
+        assert self.client.is_authenticated()
 
     def test_app_id_auth(self):
         self.client.enable_auth_backend('app-id')
@@ -140,6 +141,7 @@ class IntegrationTest(TestCase):
         result = self.client.auth_app_id('foo', 'bar')
 
         assert self.client.token == result['auth']['client_token']
+        assert self.client.is_authenticated()
 
     @raises(exceptions.InvalidPath)
     def test_invalid_path(self):
@@ -148,3 +150,14 @@ class IntegrationTest(TestCase):
     @raises(exceptions.InternalServerError)
     def test_internal_server_error(self):
         self.client.read('handler/does/not/exist')
+
+    def test_invalid_token(self):
+        client = create_client(token='not-a-real-token')
+        assert not client.is_authenticated()
+
+    def test_client_authenticated(self):
+        assert self.client.is_authenticated()
+
+    def test_client_logout(self):
+        self.client.logout()
+        assert not self.client.is_authenticated()

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -252,6 +252,19 @@ class Client(object):
         """
         self.token = None
 
+    def is_authenticated(self):
+        """
+        Helper method which returns the authentication status of the client
+        """
+        if not self.token:
+            return False
+
+        try:
+            self.lookup_token()
+            return True
+        except exceptions.InvalidPath:
+            return False
+
     def auth_app_id(self, app_id, user_id, mount_point='app-id', use_token=True):
         """
         POST /auth/<mount point>/login


### PR DESCRIPTION
I found myself externally managing the authentication state of the
Vault client, and I thought a helper method may be useful here.

I also used this method to add a check of the token provided (if any)
during client initialization. If authentication fails, a `VaultError`
is raised.