### PR TITLE
Require a modern `requests`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     keywords=['hashicorp', 'vault'],
     packages=find_packages(),
     install_requires=[
-        'requests',
+        'requests>=2.7.0',
         'six',
     ],
 )


### PR DESCRIPTION
I recently had this break on me when my system already had an old version of Requests installed.