### PR TITLE
Add support for pgp_keys when issuing a start_rekey

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -239,6 +239,29 @@ class IntegrationTest(TestCase):
 
         cls.manager.unseal()
 
+    @skipIf(util.match_version('<0.2.0'), 'Rekey API added in 0.2.0')
+    def test_rekey_multi(self):
+        cls = type(self)
+
+        assert not self.client.rekey_status['started']
+
+        self.client.start_rekey()
+        assert self.client.rekey_status['started']
+
+        self.client.cancel_rekey()
+        assert not self.client.rekey_status['started']
+
+        self.client.start_rekey()
+
+        keys = cls.manager.keys
+
+        result = self.client.rekey_multi(keys[0:2])
+        assert not result['complete']
+
+        result = self.client.rekey_multi(keys[2:3])
+        assert result['complete']
+        cls.manager.keys = result['keys']
+
     @skipIf(util.match_version('<0.2.0'), 'Rotate API added in 0.2.0')
     def test_rotate(self):
         status = self.client.key_status

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -117,7 +117,7 @@ class Client(object):
         """
         return self._get('/v1/sys/rekey/init').json()
 
-    def start_rekey(self, secret_shares=5, secret_threshold=3):
+    def start_rekey(self, secret_shares=5, secret_threshold=3, pgp_keys=None):
         """
         PUT /sys/rekey/init
         """
@@ -125,6 +125,12 @@ class Client(object):
             'secret_shares': secret_shares,
             'secret_threshold': secret_threshold,
         }
+
+        if pgp_keys:
+            if len(pgp_keys) != secret_shares:
+                raise ValueError('Length of pgp_keys must equal secret shares')
+
+            params['pgp_keys'] = pgp_keys
 
         self._put('/v1/sys/rekey/init', json=params)
 
@@ -143,6 +149,16 @@ class Client(object):
         }
 
         return self._put('/v1/sys/rekey/update', json=params).json()
+
+    def rekey_multi(self, keys):
+        result = None
+
+        for key in keys:
+            result = self.rekey(key)
+            if result['complete']:
+                break
+
+        return result
 
     @property
     def ha_status(self):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='hvac',
-    version='0.2.6',
+    version='0.2.7',
     description='HashiCorp Vault API client',
     author='Ian Unruh',
     author_email='ianunruh@gmail.com',


### PR DESCRIPTION
Also adds support for multiple keys to be passed to `rekey` via a new `rekey_multi` helper method, similar to the `unseal_multi` operation.

Integration tests pending.