### PR TITLE
Adding caching capability to Vault client

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -7,7 +7,7 @@ import requests
 
 from hvac import exceptions
 
-CachedData = namedtuple('CachedData', 'content', 'expiry')
+CachedData = namedtuple('CachedData', ['content', 'expiry'])
 
 
 class Client(object):
@@ -26,9 +26,9 @@ class Client(object):
 
     def _read_cache(self, path):
         cached_result = self._secret_cache.get(path)
-        if path is None:
+        if None in (cached_result, path):
             return None
-        if datetime.now() > cached_result.expiry:
+        if datetime.utcnow() > cached_result.expiry:
             del self._secret_cache[path]
             return None
 


### PR DESCRIPTION
This PR is just meant as a way of determining whether or not you want to include caching in the HVAC Vault client. Of course caching introduces a whole new suite of problems, so I wanted to get your input on it, @ianunruh .

This PR:

 * Adds a `cache=False` keyword arg to the `Client` instantiation. This doesn't change current behavior, but allows consumers to instantiate a caching client.
 * Adds a local (thread-safe) cache that does its best to respect Vault `lease_duration`s. If it can't find a `lease_duration` for a secret, it uses the default (30 days).
 * Adds ability to ignore the cache on any given `read()` operation.
 * Invalidates the cache when a `write()` or `delete()` operation is performed.

Again, this is just meant as an inquiry as to whether or not this behavior is desired in this Vault library. Thanks!