### PR TITLE
Methods to simplify creating new userpass, app-id & user-id records

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -204,7 +204,7 @@ class IntegrationTest(TestCase):
         if 'app-id/' not in self.client.list_auth_backends():
             self.client.enable_auth_backend('app-id')
 
-        self.client.create_app_id('testappid', 'displayname', policies='root')
+        self.client.create_app_id('testappid', policies='root', display_name='displayname')
 
         result = self.client.read('auth/app-id/map/app-id/testappid')
 
@@ -218,7 +218,7 @@ class IntegrationTest(TestCase):
         if 'app-id/' not in self.client.list_auth_backends():
             self.client.enable_auth_backend('app-id')
 
-        self.client.create_app_id('testappid', 'displayname', policies='root')
+        self.client.create_app_id('testappid', policies='root', display_name='displayname')
         self.client.create_user_id('testuserid', app_id='testappid')
 
         result = self.client.read('auth/app-id/map/user-id/testuserid')

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -392,7 +392,7 @@ class Client(object):
 
         # Users can have more than 1 policy. It is easier for the user to pass in the
         # policies as a list so if they do, we need to convert to a , delimited string.
-        if type(policies) == list:
+        if isinstance(policies, (list, set, tuple)):
             policies = ','.join(policies)
 
         params = {
@@ -409,7 +409,7 @@ class Client(object):
 
         # app-id can have more than 1 policy. It is easier for the user to pass in the
         # policies as a list so if they do, we need to convert to a , delimited string.
-        if type(policies) == list:
+        if isinstance(policies, (list, set, tuple)):
             policies = ','.join(policies)
 
         params = {
@@ -432,7 +432,7 @@ class Client(object):
 
         # user-id can be associated to more than 1 app-id (aka policy). It is easier for the user to
         # pass in the policies as a list so if they do, we need to convert to a , delimited string.
-        if type(app_id) == list:
+        if isinstance(app_id, (list, set, tuple)):
             app_id = ','.join(app_id)
 
         params = {

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -389,6 +389,9 @@ class Client(object):
         """
         POST /auth/<mount point>/users/<username>
         """
+
+        # Users can have more than 1 policy. It is easier for the user to pass in the
+        # policies as a list so if they do, we need to convert to a , delimited string.
         if type(policies) == list:
             policies = ','.join(policies)
 
@@ -404,6 +407,8 @@ class Client(object):
         POST /auth/<mount point>/map/app-id/<app_id>
         """
 
+        # app-id can have more than 1 policy. It is easier for the user to pass in the
+        # policies as a list so if they do, we need to convert to a , delimited string.
         if type(policies) == list:
             policies = ','.join(policies)
 
@@ -425,6 +430,8 @@ class Client(object):
         POST /auth/<mount point>/map/user-id/<user_id>
         """
 
+        # user-id can be associated to more than 1 app-id (aka policy). It is easier for the user to
+        # pass in the policies as a list so if they do, we need to convert to a , delimited string.
         if type(app_id) == list:
             app_id = ','.join(app_id)
 

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -385,6 +385,51 @@ class Client(object):
 
         return self.auth('/v1/auth/{}/login/{}'.format(mount_point, username), json=params, use_token=use_token)
 
+    def create_userpass(self, username, password, policies, mount_point='userpass'):
+        """
+        POST /auth/<mount point>/users/<username>
+        """
+        if type(policies) == list:
+            policies = ','.join(policies)
+
+        params = {
+            'password': password,
+            'policies': policies
+        }
+
+        return self._post('/v1/auth/{}/users/{}'.format(mount_point, username), json=params)
+
+    def create_app_id(self, app_id, display_name='', policies, mount_point='app-id', **kwargs):
+        """
+        POST /auth/<mount point>/map/app-id/<app_id>
+        """
+
+        if type(policies) == list:
+            policies = ','.join(policies)
+
+        params = {
+            'value': policies,
+            'display_name': display_name
+        }
+        params.update(kwargs)
+
+        return self._post('/v1/auth/{}/map/app-id/{}'.format(mount_point, app_id), json=params)
+
+    def create_user_id(self, user_id, app_id, mount_point='app-id', **kwargs):
+        """
+        POST /auth/<mount point>/map/user-id/<user_id>
+        """
+
+        if type(app_id) == list:
+            app_id = ','.join(app_id)
+
+        params = {
+            'value': app_id
+        }
+        params.update(kwargs)
+
+        return self._post('/v1/auth/{}/map/user-id/{}'.format(mount_point, user_id), json=params)
+
     def auth_ldap(self, username, password, mount_point='ldap', use_token=True, **kwargs):
         """
         POST /auth/<mount point>/login/<username>

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -399,7 +399,7 @@ class Client(object):
 
         return self._post('/v1/auth/{}/users/{}'.format(mount_point, username), json=params)
 
-    def create_app_id(self, app_id, display_name='', policies, mount_point='app-id', **kwargs):
+    def create_app_id(self, app_id, policies, display_name=None, mount_point='app-id', **kwargs):
         """
         POST /auth/<mount point>/map/app-id/<app_id>
         """
@@ -408,14 +408,19 @@ class Client(object):
             policies = ','.join(policies)
 
         params = {
-            'value': policies,
-            'display_name': display_name
+            'value': policies
         }
+
+        # Only use the display_name if it has a value. Made it a named param for user
+        # convienence instead of leaving it as part of the kwargs
+        if display_name:
+            params['display_name'] = display_name
+
         params.update(kwargs)
 
         return self._post('/v1/auth/{}/map/app-id/{}'.format(mount_point, app_id), json=params)
 
-    def create_user_id(self, user_id, app_id, mount_point='app-id', **kwargs):
+    def create_user_id(self, user_id, app_id, cidr_block=None, mount_point='app-id', **kwargs):
         """
         POST /auth/<mount point>/map/user-id/<user_id>
         """
@@ -426,6 +431,12 @@ class Client(object):
         params = {
             'value': app_id
         }
+
+        # Only use the cidr_block if it has a value. Made it a named param for user
+        # convienence instead of leaving it as part of the kwargs
+        if cidr_block:
+            params['cidr_block'] = cidr_block
+
         params.update(kwargs)
 
         return self._post('/v1/auth/{}/map/user-id/{}'.format(mount_point, user_id), json=params)


### PR DESCRIPTION
I add 3 methods for helping make it easier (and obvious) to create new userpass, app-id & user-id records. I know that you could always call the `write` method with the full path but I felt that these methods are easier for users to understand.

The policies and app_id can be passed in as a string `policies='foo,bar'` or as a list `policies=['foo','bar']`. I felt it was easier to allow the list when a user has more than 1 policy instead of making sure the string was built properly.