### PR TITLE
Add support for nonce during rekey operation

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -136,6 +136,26 @@ class IntegrationTest(TestCase):
         self.client.delete_policy('test')
         assert 'test' not in self.client.list_policies()
 
+    def test_json_policy_manipulation(self):
+        assert 'root' in self.client.list_policies()
+
+        policy = {
+            "path": {
+                "sys": {
+                    "policy": "deny"
+                },
+                "secret": {
+                    "policy": "write"
+                }
+            }
+        }
+
+        self.client.set_policy('test', policy)
+        assert 'test' in self.client.list_policies()
+
+        self.client.delete_policy('test')
+        assert 'test' not in self.client.list_policies()
+
     def test_auth_token_manipulation(self):
         result = self.client.create_token(lease='1h')
         assert result['auth']['client_token']

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -143,7 +143,7 @@ class Client(object):
         """
         self._delete('/v1/sys/rekey/init')
 
-    def rekey(self, key):
+    def rekey(self, key, nonce=None):
         """
         PUT /sys/rekey/update
         """
@@ -151,13 +151,16 @@ class Client(object):
             'key': key,
         }
 
+        if nonce:
+            params['nonce'] = nonce
+
         return self._put('/v1/sys/rekey/update', json=params).json()
 
-    def rekey_multi(self, keys):
+    def rekey_multi(self, keys, nonce=None):
         result = None
 
         for key in keys:
-            result = self.rekey(key)
+            result = self.rekey(key, nonce=nonce)
             if result['complete']:
                 break
 


### PR DESCRIPTION
A nonce was added to the rekey operation in Vault 0.5.0. This PR provides an opportunity to provide that information.

Also, a test for JSON policies that I should have included in #33 from a while back.