### PR TITLE
add a 'get' companion for policies

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -119,6 +119,7 @@ class IntegrationTest(TestCase):
 
     def test_policy_manipulation(self):
         assert 'root' in self.client.list_policies()
+        assert self.client.get_policy('test') is None
 
         policy = """
         path "sys" {
@@ -132,6 +133,7 @@ class IntegrationTest(TestCase):
 
         self.client.set_policy('test', policy)
         assert 'test' in self.client.list_policies()
+        assert policy == self.client.get_policy('test')
 
         self.client.delete_policy('test')
         assert 'test' not in self.client.list_policies()

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -241,6 +241,15 @@ class Client(object):
         """
         return self._get('/v1/sys/policy').json()['policies']
 
+    def get_policy(self, name):
+        """
+        GET /sys/policy/<name>
+        """
+        try:
+            return self._get('/v1/sys/policy/{0}'.format(name)).json()['rules']
+        except exceptions.InvalidPath:
+            return None
+
     def set_policy(self, name, rules):
         """
         PUT /sys/policy/<name>


### PR DESCRIPTION
Basic rouding out of functionality.  Note that a simple `read` api
call is not sufficient to retrieve the original policy string.