### PR TITLE
fix rekey tests for vault 0.5.x

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -294,10 +294,13 @@ class IntegrationTest(TestCase):
         self.client.cancel_rekey()
         assert not self.client.rekey_status['started']
 
-        self.client.start_rekey()
+        rekey_info = self.client.start_rekey()
 
+        nonce = None
+        if util.match_version('>0.5.0'):
+            nonce = rekey_info['nonce']
         for key in cls.manager.keys:
-            result = self.client.rekey(key)
+            result = self.client.rekey(key, nonce=nonce)
             if result['complete']:
                 cls.manager.keys = result['keys']
                 assert not self.client.rekey_status['started']
@@ -317,14 +320,16 @@ class IntegrationTest(TestCase):
         self.client.cancel_rekey()
         assert not self.client.rekey_status['started']
 
-        self.client.start_rekey()
-
+        rekey_info = self.client.start_rekey()
+        nonce = None
+        if util.match_version('>0.5.0'):
+            nonce = rekey_info['nonce']
         keys = cls.manager.keys
 
-        result = self.client.rekey_multi(keys[0:2])
+        result = self.client.rekey_multi(keys[0:2], nonce=nonce)
         assert not result['complete']
 
-        result = self.client.rekey_multi(keys[2:3])
+        result = self.client.rekey_multi(keys[2:3], nonce=nonce)
         assert result['complete']
         cls.manager.keys = result['keys']
 

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -135,7 +135,7 @@ class Client(object):
 
             params['pgp_keys'] = pgp_keys
 
-        self._put('/v1/sys/rekey/init', json=params)
+        return self._put('/v1/sys/rekey/init', json=params).json()
 
     def cancel_rekey(self):
         """


### PR DESCRIPTION
To quote from the 0.5.x docs 'The rekey nonce operation must be
provided with each call.'.  This requires start_rekey to return
something other than None, which I believe is an innocuous api change.

fixes #40