### PR TITLE
add a delete companion method for userpass

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -204,6 +204,20 @@ class IntegrationTest(TestCase):
 
         self.client.disable_auth_backend('userpass')
 
+    def test_delete_userpass(self):
+        if 'userpass/' not in self.client.list_auth_backends():
+            self.client.enable_auth_backend('userpass')
+
+        self.client.create_userpass('testcreateuser', 'testcreateuserpass', policies='root')
+
+        result = self.client.auth_userpass('testcreateuser', 'testcreateuserpass')
+
+        assert self.client.token == result['auth']['client_token']
+        assert self.client.is_authenticated()
+
+        self.client.delete_userpass('testcreateuser')
+        assert_raises(exceptions.InvalidRequest, self.client.auth_userpass, 'testcreateuser', 'testcreateuserpass')
+
     def test_app_id_auth(self):
         if 'app-id/' in self.client.list_auth_backends():
             self.client.disable_auth_backend('app-id')

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -435,6 +435,12 @@ class Client(object):
 
         return self._post('/v1/auth/{}/users/{}'.format(mount_point, username), json=params)
 
+    def delete_userpass(self, username, mount_point='userpass'):
+        """
+        DELETE /auth/<mount point>/users/<username>
+        """
+        return self._delete('/v1/auth/{}/users/{}'.format(mount_point, username))
+
     def create_app_id(self, app_id, policies, display_name=None, mount_point='app-id', **kwargs):
         """
         POST /auth/<mount point>/map/app-id/<app_id>


### PR DESCRIPTION
Quality of live improvement so downstream users do not have to
duplicate the path & mountpoint manipulation logic while calling
client.delete.