### PR TITLE
Fix write errors when path contains unicode chars

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import json
 import requests
 


### PR DESCRIPTION
This fix is trivial, just import `unicode_literals`. Without this would fail when using Python 2:

```python
client = Client(token=myToken)
client.write('secret/Unicodeßstringé', value='unicode ftw!')
```