### PR TITLE
Adding ttl option to create_userpass

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -217,6 +217,13 @@ class IntegrationTest(TestCase):
         assert self.client.token == result['auth']['client_token']
         assert self.client.is_authenticated()
 
+        # Test ttl:
+        self.client.create_userpass('testcreateuser', 'testcreateuserpass', policies='root', ttl='10s')
+        
+        result = self.client.auth_userpass('testcreateuser', 'testcreateuserpass')
+
+        assert result['auth']['lease_duration'] == 10
+
         self.client.disable_auth_backend('userpass')
 
     def test_delete_userpass(self):

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -465,7 +465,7 @@ class Client(object):
 
         return self.auth('/v1/auth/{0}/login/{1}'.format(mount_point, username), json=params, use_token=use_token)
 
-    def create_userpass(self, username, password, policies, mount_point='userpass'):
+    def create_userpass(self, username, password, policies, mount_point='userpass', **kwargs):
         """
         POST /auth/<mount point>/users/<username>
         """
@@ -479,6 +479,7 @@ class Client(object):
             'password': password,
             'policies': policies
         }
+        params.update(kwargs)
 
         return self._post('/v1/auth/{}/users/{}'.format(mount_point, username), json=params)
 

--- a/scripts/install-vault-release.sh
+++ b/scripts/install-vault-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 
-VAULT_VERSION=0.5.1
+VAULT_VERSION=0.5.2
 
 mkdir -p $HOME/bin
 


### PR DESCRIPTION
Currently, you can't pass a `ttl` option through the `create_userpass` function. Many other functions accept `kwargs` and pass these to the POST/GET, so I followed a similar approach here. Also added a test.