### PR TITLE
Support for Response wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ client.revoke_token_prefix('zzz')
 client.renew_token('aaa')
 ```
 
+### Managing tokens using accessors
+
+```python
+token = client.create_token(policies=['root'], lease='1h')
+token_accessor = token['auth']['accessor']
+
+same_token = client.lookup_token(token_accessor, accessor=True)
+client.revoke_token(token_accessor, accessor=True)
+```
+
 ### Manipulate auth backends
 
 ```python

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ same_token = client.lookup_token(token_accessor, accessor=True)
 client.revoke_token(token_accessor, accessor=True)
 ```
 
+### Wrapping/unwrapping a token
+
+```python
+wrap = client.create_token(policies=['root'], lease='1h', wrap_ttl='1m')
+result = self.client.unwrap(wrap['wrap_info']['token'])
+```
+
 ### Manipulate auth backends
 
 ```python

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -385,22 +385,31 @@ class Client(object):
         else:
             return self._post('/v1/auth/token/create', json=params).json()
 
-    def lookup_token(self, token=None):
+    def lookup_token(self, token=None, accessor=False):
         """
         GET /auth/token/lookup/<token>
+        GET /auth/token/lookup-accessor/<token-accessor>
         GET /auth/token/lookup-self
         """
         if token:
-            return self._get('/v1/auth/token/lookup/{0}'.format(token)).json()
+            if accessor:
+                return self._post('/v1/auth/token/lookup-accessor/{0}'.format(token)).json()
+            else:
+                return self._get('/v1/auth/token/lookup/{0}'.format(token)).json()
         else:
             return self._get('/v1/auth/token/lookup-self').json()
 
-    def revoke_token(self, token, orphan=False):
+    def revoke_token(self, token, orphan=False, accessor=False):
         """
         POST /auth/token/revoke/<token>
         POST /auth/token/revoke-orphan/<token>
+        POST /auth/token/revoke-accessor/<token-accessor>
         """
-        if orphan:
+        if accessor and orphan:
+            raise exceptions.InvalidRequest("token-revoke cannot be run for 'orphan' mode when 'accessor' flag is set")
+        elif accessor:
+            self._post('/v1/auth/token/revoke-accessor/{0}'.format(token))
+        elif orphan:
             self._post('/v1/auth/token/revoke-orphan/{0}'.format(token))
         else:
             self._post('/v1/auth/token/revoke/{0}'.format(token))


### PR DESCRIPTION
Added the `wrap_ttl` kwarg to the following client methods: `read`, `unwrap`, `create_token`, `lookup_token`, `renew_token`, `get_app_id`, `get_user_id`.

Also added a new client method: `unwrap`.

This PR is built on top of the same branch in #69 because the unittests added here depend on accessors.

This closes #67.