### PR TITLE
Remove auth_ec2 json response double parsing

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -515,7 +515,7 @@ class Client(object):
         if role:
             params['role'] = role
 
-        return self.auth('/v1/auth/aws-ec2/login', json=params, use_token=use_token).json()
+        return self.auth('/v1/auth/aws-ec2/login', json=params, use_token=use_token)
 
     def create_userpass(self, username, password, policies, mount_point='userpass', **kwargs):
         """


### PR DESCRIPTION
`auth` method already parses the response as json.
https://github.com/ianunruh/hvac/blob/master/hvac/v1/__init__.py#L743

trying to re-parse gives the following error:
```
 File "/usr/src/app/hvac/v1/__init__.py", line 518, in auth_ec2
    return self.auth('/v1/auth/aws-ec2/login', json=params, use_token=use_token).json()
AttributeError: 'dict' object has no attribute 'json'
```

Thanks for your awesome work! =]