### PR TITLE
Add support for 501 status code when Vault is uninitialized

### DIFF
--- a/hvac/exceptions.py
+++ b/hvac/exceptions.py
@@ -25,6 +25,9 @@ class RateLimitExceeded(VaultError):
 class InternalServerError(VaultError):
     pass
 
+class VaultNotInitialized(VaultError):
+    pass
+
 class VaultDown(VaultError):
     pass
 

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -950,6 +950,8 @@ class Client(object):
             raise exceptions.RateLimitExceeded(message, errors=errors)
         elif status_code == 500:
             raise exceptions.InternalServerError(message, errors=errors)
+        elif status_code == 501:
+            raise exceptions.VaultNotInitialized(message, errors=errors)
         elif status_code == 503:
             raise exceptions.VaultDown(message, errors=errors)
         else:


### PR DESCRIPTION
Closes https://github.com/ianunruh/hvac/issues/78.

Adds an exception type of `VaultNotInitialized`, to be thrown when Vault responds with the status code 501. This behavior is new to Vault as of version 0.6.1. Details can be found here: https://www.vaultproject.io/docs/install/upgrade-to-0.6.1.html

I have tested this change by installing hvac as an editable package (with `pip install -e`) and running a script which utilizes hvac against an uninitialized cluster. I confirmed that hvac raises `hvac.exceptions.VaultNotInitialized` where it previously raised `hvac.exceptions.UnexpectedError`.