### PR TITLE
Added missing method(s) to tune a mount.

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -112,13 +112,13 @@ class IntegrationTest(TestCase):
 
     def test_secret_backend_manipulation(self):
         assert 'test/' not in self.client.list_secret_backends()
-
+        print ("test")
         self.client.enable_secret_backend('generic', mount_point='test')
         assert 'test/' in self.client.list_secret_backends()
 
         self.client.tune_secret_backend('generic', mount_point='test', default_lease_ttl='3600s', max_lease_ttl='8600s')
-        assert '3600s' in self.client.get_secret_backend_tuning()
-        assert '8600s' in self.client.get_secret_backend_tuning()
+        assert '3600s' in self.client.get_secret_backend_tuning('generic', mount_point='test')
+        assert '8600s' in self.client.get_secret_backend_tuning('generic', mount_point='test')
 
         self.client.remount_secret_backend('test', 'foobar')
         assert 'test/' not in self.client.list_secret_backends()

--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -112,13 +112,13 @@ class IntegrationTest(TestCase):
 
     def test_secret_backend_manipulation(self):
         assert 'test/' not in self.client.list_secret_backends()
-        print ("test")
+
         self.client.enable_secret_backend('generic', mount_point='test')
         assert 'test/' in self.client.list_secret_backends()
 
         self.client.tune_secret_backend('generic', mount_point='test', default_lease_ttl='3600s', max_lease_ttl='8600s')
-        assert '3600s' in self.client.get_secret_backend_tuning('generic', mount_point='test')
-        assert '8600s' in self.client.get_secret_backend_tuning('generic', mount_point='test')
+        assert 'max_lease_ttl' in self.client.get_secret_backend_tuning('generic', mount_point='test')
+        assert 'default_lease_ttl' in self.client.get_secret_backend_tuning('generic', mount_point='test')
 
         self.client.remount_secret_backend('test', 'foobar')
         assert 'test/' not in self.client.list_secret_backends()

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -279,6 +279,7 @@ class Client(object):
         """
         POST /sys/mounts/<mount point>/tune
         """
+        print ("test")
         if not mount_point:
             mount_point = backend_type
 
@@ -289,7 +290,7 @@ class Client(object):
 
         self._post('/v1/sys/mounts/{0}/tune'.format(mount_point), json=params)
 
-    def get_secret_backend_tuning(self, backend_type, mount_point=None, default_lease_ttl=None, max_lease_ttl=None):
+    def get_secret_backend_tuning(self, backend_type, mount_point=None):
         """
         GET /sys/mounts/<mount point>/tune
         """


### PR DESCRIPTION
Added tune_secret_backend and get_secret_backend_tuning. In the Vault documentation for the pki backend, there is an example:

```
$ vault mount-tune -max-lease-ttl=87600h pki
```

I couldn't find this in your module, so I added it.
