### PR TITLE
Add use_token flag to the auth_approle function

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -387,6 +387,22 @@ class IntegrationTest(TestCase):
         role_id = self.client.get_role_id('testrole')
         result = self.client.auth_approle(role_id, secret_id)
         assert result['auth']['metadata']['foo'] == 'bar'
+        assert self.client.token != result['auth']['client_token']
+        self.client.token = self.root_token()
+        self.client.disable_auth_backend('approle')
+
+    def test_auth_approle_use_token(self):
+        if 'approle/' in self.client.list_auth_backends():
+            self.client.disable_auth_backend('approle')
+        self.client.enable_auth_backend('approle')
+
+        self.client.create_role('testrole')
+        create_result = self.client.create_role_secret_id('testrole', {'foo':'bar'})
+        secret_id = create_result['data']['secret_id']
+        role_id = self.client.get_role_id('testrole')
+        result = self.client.auth_approle(role_id, secret_id, use_token=True)
+        assert result['auth']['metadata']['foo'] == 'bar'
+        assert self.client.token == result['auth']['client_token']
         self.client.token = self.root_token()
         self.client.disable_auth_backend('approle')        
 

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -875,7 +875,7 @@ class Client(object):
             params['meta'] = meta
         return self._post(url, json=params).json()
 
-    def auth_approle(self, role_id, secret_id=None):
+    def auth_approle(self, role_id, secret_id=None, use_token=False):
         """
         POST /auth/approle/login
         """
@@ -885,7 +885,11 @@ class Client(object):
         if secret_id is not None:
             params['secret_id'] = secret_id
 
-        return self._post('/v1/auth/approle/login', json=params).json()
+        response = self._post('/v1/auth/approle/login', json=params).json()
+        if use_token:
+            self.token = response['auth']['client_token']
+
+        return response
 
     def close(self):
         """


### PR DESCRIPTION
Add `use_token` flag to the `auth_approle` function. Unlike the other methods, it needs to default to False for backwards compatibility.