### PR TITLE
fix(approle): Update approle secret-id endpoints, tests

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -371,10 +371,10 @@ class IntegrationTest(TestCase):
         try:
             self.client.get_role_secret_id('testrole', secret_id)
             assert False
-        except exceptions.InvalidPath:
+        except ValueError:
             assert True
         self.client.token = self.root_token()
-        self.client.disable_auth_backend('approle')        
+        self.client.disable_auth_backend('approle')
 
     def test_auth_approle(self):
         if 'approle/' in self.client.list_auth_backends():
@@ -388,7 +388,7 @@ class IntegrationTest(TestCase):
         result = self.client.auth_approle(role_id, secret_id)
         assert result['auth']['metadata']['foo'] == 'bar'
         self.client.token = self.root_token()
-        self.client.disable_auth_backend('approle')        
+        self.client.disable_auth_backend('approle')
 
     def test_missing_token(self):
         client = create_client()

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -830,10 +830,13 @@ class Client(object):
 
     def get_role_secret_id(self, role_name, secret_id):
         """
-        GET /auth/approle/role/<role name>/secret-id/<secret_id>
+        POST /auth/approle/role/<role name>/secret-id/lookup
         """
-        url = '/v1/auth/approle/role/{0}/secret-id/{1}'.format(role_name, secret_id)
-        return self._get(url).json()
+        url = '/v1/auth/approle/role/{0}/secret-id/lookup'.format(role_name)
+        params = {
+            'secret_id': secret_id
+        }
+        return self._post(url, json=params).json()
 
     def list_role_secrets(self, role_name):
         """
@@ -851,10 +854,13 @@ class Client(object):
 
     def delete_role_secret_id(self, role_name, secret_id):
         """
-        DELETE /auth/approle/role/<role name>/secret-id/<secret_id>
+        POST /auth/approle/role/<role name>/secret-id/destroy
         """
-        url = '/v1/auth/approle/role/{0}/secret-id/{1}'.format(role_name, secret_id)
-        self._delete(url)
+        url = '/v1/auth/approle/role/{0}/secret-id/destroy'.format(role_name)
+        params = {
+            'secret_id': secret_id
+        }
+        self._post(url, json=params)
 
     def delete_role_secret_id_accessor(self, role_name, secret_id_accessor):
         """

--- a/scripts/install-vault-release.sh
+++ b/scripts/install-vault-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 
-VAULT_VERSION=0.6.1
+VAULT_VERSION=0.6.2
 
 mkdir -p $HOME/bin
 


### PR DESCRIPTION
It seems the endpoints have changed in recent Vault versions because
including the `secret-id` in the url resulted in those ids being logged in 
cleartext. (See: https://github.com/hashicorp/vault/issues/1944)

Now get and delete operations are performed with POSTs against
`.../lookup` and `.../destroy` respectively with secret-ids specified in
the request body. (See: https://www.vaultproject.io/docs/auth/approle.html)
