### PR TITLE
refactor(auth/token): Break out token roles functionality

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -10,6 +10,7 @@ except ImportError:
 import requests
 
 from hvac import exceptions
+from .token_roles import TokenRoles
 
 try:
     from urlparse import urljoin
@@ -27,6 +28,8 @@ class Client(object):
         self.allow_redirects = allow_redirects
         self.session = session
         self.token = token
+
+        self.token_roles = TokenRoles(self)
 
         self._url = url
         self._kwargs = {
@@ -458,41 +461,6 @@ class Client(object):
             return self._post(path, json=params, wrap_ttl=wrap_ttl).json()
         else:
             return self._post('/v1/auth/token/renew-self', json=params, wrap_ttl=wrap_ttl).json()
-
-    def create_token_role(self, role,
-                          allowed_policies=None, orphan=None, period=None,
-                          renewable=None, path_suffix=None, explicit_max_ttl=None):
-        """
-        POST /auth/token/roles/<role>
-        """
-        params = {
-            'allowed_policies': allowed_policies,
-            'orphan': orphan,
-            'period': period,
-            'renewable': renewable,
-            'path_suffix': path_suffix,
-            'explicit_max_ttl': explicit_max_ttl
-        }
-        return self._post('/v1/auth/token/roles/{0}'.format(role), json=params)
-
-    def token_role(self, role):
-        """
-        Returns the named token role.
-        """
-        return self.read('auth/token/roles/{0}'.format(role))
-
-    def delete_token_role(self, role):
-        """
-        Deletes the named token role.
-        """
-        return self.delete('auth/token/roles/{0}'.format(role))
-
-    def list_token_roles(self):
-        """
-        GET /auth/token/roles?list=true
-        """
-        return self.list('auth/token/roles')
-
 
     def logout(self, revoke_token=False):
         """

--- a/hvac/v1/client.py
+++ b/hvac/v1/client.py
@@ -1,0 +1,19 @@
+class ClientFeature(object):
+    """
+    Redirects calls to client methods to the parent client
+    """
+
+    def __init__(self, client):
+        self.client = client
+
+    def _post(self, *args, **kwargs):
+        return self.client._post(*args, **kwargs)
+
+    def _read(self, *args, **kwargs):
+        return self.client.read(*args, **kwargs)
+
+    def _delete(self, *args, **kwargs):
+        return self.client.delete(*args, **kwargs)
+
+    def _list(self, *args, **kwargs):
+        return self.client.list(*args, **kwargs)

--- a/hvac/v1/token_roles.py
+++ b/hvac/v1/token_roles.py
@@ -1,0 +1,36 @@
+from .client import ClientFeature
+
+class TokenRoles(ClientFeature):
+    def write(self, role, allowed_policies=None, orphan=None, period=None,
+                          renewable=None, path_suffix=None, explicit_max_ttl=None):
+        """
+        POST /auth/token/roles/<role>
+        """
+        params = {
+            'allowed_policies': allowed_policies,
+            'orphan': orphan,
+            'period': period,
+            'renewable': renewable,
+            'path_suffix': path_suffix,
+            'explicit_max_ttl': explicit_max_ttl
+        }
+
+        return self._post('/v1/auth/token/roles/{0}'.format(role), json=params)
+
+    def read(self, role):
+        """
+        Returns the named token role.
+        """
+        return self._read('auth/token/roles/{0}'.format(role))
+
+    def delete(self, role):
+        """
+        Deletes the named token role.
+        """
+        return self._delete('auth/token/roles/{0}'.format(role))
+
+    def list(self):
+        """
+        GET /auth/token/roles?list=true
+        """
+        return self._list('auth/token/roles')


### PR DESCRIPTION
I wanted to get a head start on this while the token roles stuff was fresh in my mind!

I've added two new classes: ClientFeature and TokenRoles. The former is a wrapper around the client for the basic API calls (post, read, list and delete). The later inherits the former and is where the new token roles functionality lives.

Also added further checks to current tests.

Motivation for changes is as discussed in #95.

**BREAKING CHANGES:**

* token_role(...) -> token_roles.read(...)
* list_token_roles(...) -> token_roles.list(...)
* create_token_role(...) -> token_roles.write(...)
* delete_token_role(...) -> token_roles.delete(...)