### PR TITLE
Decode the response object when listing ec2 roles

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -607,6 +607,11 @@ class IntegrationTest(TestCase):
         # create a policy to associate with the role
         self.prep_policy('ec2rolepolicy')
 
+        # attempt to get a list of roles before any exist
+        no_roles = self.client.list_ec2_roles()
+        # doing so should succeed and return None
+        assert (no_roles is None)
+
         # TODO test parameters of role creation more thoroughly
         self.client.create_ec2_role('foo', 'ami-notarealami',
                                     policies='ec2rolepolicy')

--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -598,3 +598,28 @@ class IntegrationTest(TestCase):
         # Cleanup
         self.client.delete_token_role('testrole')
         self.client.delete_policy('testpolicy')
+
+    def test_ec2_role_crud(self):
+        if 'aws-ec2/' in self.client.list_auth_backends():
+            self.client.disable_auth_backend('aws-ec2')
+        self.client.enable_auth_backend('aws-ec2')
+
+        # create a policy to associate with the role
+        self.prep_policy('ec2rolepolicy')
+
+        # TODO test parameters of role creation more thoroughly
+        self.client.create_ec2_role('foo', 'ami-notarealami',
+                                    policies='ec2rolepolicy')
+
+        roles = self.client.list_ec2_roles()
+
+        assert('foo' in roles['data']['keys'])
+
+        role = self.client.get_ec2_role('foo')
+
+        assert('ec2rolepolicy' in role['data']['policies'])
+
+        self.client.delete_ec2_role('foo')
+        self.client.delete_policy('ec2rolepolicy')
+
+        self.client.disable_auth_backend('aws-ec2')

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -740,7 +740,10 @@ class Client(object):
         """
         GET /auth/aws-ec2/roles?list=true
         """
-        return self._get('/v1/auth/aws-ec2/roles', params={'list': True}).json()
+        try:
+            return self._get('/v1/auth/aws-ec2/roles', params={'list': True}).json()
+        except exceptions.InvalidPath:
+            return None
 
     def create_ec2_role_tag(self, role, policies=None, max_ttl=None, instance_id=None,
                             disallow_reauthentication=False, allow_instance_migration=False):

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -740,7 +740,7 @@ class Client(object):
         """
         GET /auth/aws-ec2/roles?list=true
         """
-        return self._get('/v1/auth/aws-ec2/roles', params={'list': True})
+        return self._get('/v1/auth/aws-ec2/roles', params={'list': True}).json()
 
     def create_ec2_role_tag(self, role, policies=None, max_ttl=None, instance_id=None,
                             disallow_reauthentication=False, allow_instance_migration=False):


### PR DESCRIPTION
While writing code which manages EC2 roles in Vault, I noticed that the `list_ec2_roles()` method returns a `requests.Response` object, whereas other `GET`-based methods generally return a dict (decoded from the JSON response from Vault). I suspect this was an omission in the original code, but the fix is pretty straightforward. I also wrote some (very) minimal testing around EC2 role CRUD to ensure coverage of the fix. 

/cc @blarghmatey, who contributed the original code in https://github.com/ianunruh/hvac/pull/61, in case this change breaks something for you 😃 