### PR TITLE
fix client.renew_secret: use PUT request and pass lease_id as JSON

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -229,12 +229,13 @@ class Client(object):
 
     def renew_secret(self, lease_id, increment=None):
         """
-        PUT /sys/renew/<lease id>
+        PUT /sys/renew
         """
-        params = {
-            'increment': increment,
-        }
-        return self._post('/v1/sys/renew/{0}'.format(lease_id), json=params).json()
+        params = {'lease_id': lease_id}
+        if increment:
+            params['increment'] = increment
+
+        return self._put('/v1/sys/renew', json=params).json()
 
     def revoke_secret(self, lease_id):
         """


### PR DESCRIPTION
- The documentation suggests [`PUT` should be used](https://www.vaultproject.io/docs/http/sys-renew.html), not `POST`
- Renewing with the request `PUT` `/v1/renew/<lease_id>` fails (perhaps an upstream issue of Vault 0.6.2) though passing `lease_id` as a JSON parameter works
