### PR TITLE
fix #88 use self.auth for approle auth.

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -381,6 +381,9 @@ class IntegrationTest(TestCase):
         role_id = self.client.get_role_id('testrole')
         result = self.client.auth_approle(role_id, secret_id)
         assert result['auth']['metadata']['foo'] == 'bar'
+        assert self.client.token == result['auth']['client_token']
+        assert self.client.is_authenticated()
+
         self.client.token = self.root_token()
         self.client.disable_auth_backend('approle')
 

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -921,7 +921,7 @@ class Client(object):
             params['meta'] = meta
         return self._post(url, json=params).json()
 
-    def auth_approle(self, role_id, secret_id=None):
+    def auth_approle(self, role_id, secret_id=None, mount_point='approle', use_token=True):
         """
         POST /auth/approle/login
         """
@@ -931,7 +931,7 @@ class Client(object):
         if secret_id is not None:
             params['secret_id'] = secret_id
 
-        return self._post('/v1/auth/approle/login', json=params).json()
+        return self.auth('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
 
     def close(self):
         """


### PR DESCRIPTION
This commit fix the issue #88 by using self.auth on approle auth.

Approle feature come from https://github.com/ianunruh/hvac/pull/77
but don't use `self.auth` as others auth methode like github, ...

This commit now allow you to auth directly with `client.auth_approle(role_id, secret_id)`.