### PR TITLE
Add wrap_ttl to create_role_secret_id(..)

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -856,7 +856,7 @@ class Client(object):
         """
         return self._get('/v1/auth/approle/role/{0}'.format(role_name)).json()
 
-    def create_role_secret_id(self, role_name, meta=None):
+    def create_role_secret_id(self, role_name, meta=None, wrap_ttl=None):
         """
         POST /auth/approle/role/<role name>/secret-id
         """
@@ -866,7 +866,7 @@ class Client(object):
         if meta is not None:
             params['metadata'] = json.dumps(meta)
 
-        return self._post(url, json=params).json()
+        return self._post(url, json=params, wrap_ttl=wrap_ttl).json()
 
     def get_role_secret_id(self, role_name, secret_id):
         """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='hvac',
-    version='0.2.17',
+    version='0.2.17.1',
     description='HashiCorp Vault API client',
     author='Ian Unruh',
     author_email='ianunruh@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='hvac',
-    version='0.2.17.1',
+    name='alooma-hvac',
+    version='0.2.18',
     description='HashiCorp Vault API client',
-    author='Ian Unruh',
-    author_email='ianunruh@gmail.com',
-    url='https://github.com/ianunruh/hvac',
+    author='Ram Amar',
+    author_email='rami@alooma.com',
+    url='https://github.com/Aloomaio/alooma-hvac',
     keywords=['hashicorp', 'vault'],
     classifiers=['License :: OSI Approved :: Apache Software License'],
     packages=find_packages(),


### PR DESCRIPTION
1. Adding `wrap_ttl` to the method `Client.create_role_secret_id` allows getting a wrapped secret_id and only then passing it on to an app/machine/service which requires it.
2. `Client.auth_approle` now uses the `auth(...)` method and uses the client_token (instead of using `_post` and just returning the response)

Simple changes, important functionality.

🙏 thanks for considering