### PR TITLE
Send token/accessor as a payload to avoid being logged

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -422,20 +422,23 @@ class Client(object):
             return self._get('/v1/auth/token/lookup-self', wrap_ttl=wrap_ttl).json()
 
     def revoke_token(self, token, orphan=False, accessor=False):
-        """
-        POST /auth/token/revoke/<token>
-        POST /auth/token/revoke-orphan/<token>
-        POST /auth/token/revoke-accessor/<token-accessor>
-        """
-        if accessor and orphan:
-            msg = "revoke_token does not support 'orphan' and 'accessor' flags together"
-            raise exceptions.InvalidRequest(msg)
-        elif accessor:
-            self._post('/v1/auth/token/revoke-accessor/{0}'.format(token))
-        elif orphan:
-            self._post('/v1/auth/token/revoke-orphan/{0}'.format(token))
-        else:
-            self._post('/v1/auth/token/revoke/{0}'.format(token))
+         """
+         POST /auth/token/revoke
+         POST /auth/token/revoke-orphan
+         POST /auth/token/revoke-accessor
+         """
+         if accessor and orphan:
+             msg = "revoke_token does not support 'orphan' and 'accessor' flags together"
+             raise exceptions.InvalidRequest(msg)
+         elif accessor:
+             params = { 'accessor': token }
+             self._post('/v1/auth/token/revoke-accessor', json=params)
+         elif orphan:
+             params = { 'token': token }
+             self._post('/v1/auth/token/revoke-orphan', json=params)
+         else:
+             params = { 'token': token }
+             self._post('/v1/auth/token/revoke', json=params)
 
     def revoke_token_prefix(self, prefix):
         """


### PR DESCRIPTION
So sending the accessor as a payload avoids the token being logged in plain text.

Thanks for your time 

```
curl -vv -XPOST -H "X-Vault-Token: c82d1250-a92d-dd9e-6506-cfe387e93a95" https://my-vault-instance:8200/v1/auth/token/revoke-accessor/dd5863a0-eea6-8f73-b376-c77cbad771ed

*   Trying 10.2.68.149...
* TCP_NODELAY set
* Connected to my-vault-instance (10.2.68.149) port 8200 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
* Server certificate: *.my-vault-instance
* Server certificate: Internal2017C1
* Server certificate: Root2017
> POST /v1/auth/token/revoke-accessor/dd5863a0-eea6-8f73-b376-c77cbad771ed HTTP/1.1
...


curl -vv -XPOST -H "X-Vault-Token: c82d1250-a92d-dd9e-6506-cfe387e93a95" https://my-vault-instance:8200/v1/auth/token/revoke-accessor -d'{"accessor": "dd5863a0-eea6-8f73-b376-c77cbad771ed" }'
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 10.2.68.149...
* TCP_NODELAY set
* Connected to my-vault-instance (10.2.68.149) port 8200 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
* Server certificate: *.my-vault-instance
* Server certificate: Internal2017C1
* Server certificate: Root2017
> POST /v1/auth/token/revoke-accessor HTTP/1.1
> Host: my-vault-instance:8200
> User-Agent: curl/7.51.0
> Accept: */*
> X-Vault-Token: c82d1250-a92d-dd9e-6506-cfe387e93a95
> Content-Length: 53
> Content-Type: application/x-www-form-urlencoded
....
``` 