### PR TITLE
Bug Fixes

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -217,7 +217,7 @@ class Client(object):
 
         for key in keys:
             result = self.rekey(key, nonce=nonce)
-            if result['complete']:
+            if 'complete' in result and result['complete']:
                 break
 
         return result

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -237,7 +237,7 @@ class Client(object):
 
     def renew_secret(self, lease_id, increment=None):
         """
-        PUT /sys/renew/
+        PUT /sys/leases/renew
         """
         params = {
             'lease_id': lease_id,

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -243,7 +243,7 @@ class Client(object):
             'lease_id': lease_id,
             'increment': increment,
         }
-        return self._put('/v1/sys/leases/renew').json()
+        return self._put('/v1/sys/leases/renew', json=params).json()
 
     def revoke_secret(self, lease_id):
         """

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -237,12 +237,13 @@ class Client(object):
 
     def renew_secret(self, lease_id, increment=None):
         """
-        PUT /sys/renew/<lease id>
+        PUT /sys/renew/
         """
         params = {
+            'lease_id': lease_id,
             'increment': increment,
         }
-        return self._post('/v1/sys/renew/{0}'.format(lease_id), json=params).json()
+        return self._put('/v1/sys/leases/renew').json()
 
     def revoke_secret(self, lease_id):
         """


### PR DESCRIPTION
This PR includes two changes:

1. Changing the lease renewal API call to hit `/sys/leases/renew` with a JSON payload containing the lease ID and lease increment, instead of hitting the API endpoint `/sys/leases/renew/<lease_id>`. Although Vault `0.8.1` will accept both calls, the [official API documentation](url) describes the format contained in this fix. The new format also prevents the lease ID from being cached by removing its inclusion in the request URL.

2. The integration tests currently fail during the rekey test, as the `complete` parameter is only returned once the rekey progress has finished. This fix allows the test to pass by first testing if the `complete` parameter exists within the response dictionary.