### PR TITLE
Specify Python Versions To Test Against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 dist: trusty
 sudo: required
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.5"
 matrix:
   include:
     - python: '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: trusty
 sudo: required
 language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.5"
 install:
   - scripts/install-vault-${VAULT_BRANCH}.sh
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,14 @@ sudo: required
 language: python
 matrix:
   include:
+    - python: '2.6'
+      env: TOXENV=py26 VAULT_BRANCH=release
     - python: '2.7'
       env: TOXENV=py27 VAULT_BRANCH=release
     - python: '3.5'
       env: TOXENV=py35 VAULT_BRANCH=release
+    - python: '3.5'
+      env: TOXENV=py35 VAULT_BRANCH=head
   allow_failures:
     - python: '2.6'
       env: TOXENV=py26 VAULT_BRANCH=release

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
 install:
   - scripts/install-vault-${VAULT_BRANCH}.sh
   - pip install tox
-env:  # https://docs.travis-ci.com/user/customizing-the-build/#Matching-Jobs-with-allow_failures
 matrix:
   include:
     - python: '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 dist: trusty
 sudo: required
 language: python
+# Explicitly declare which builds should run, otherwise Travis CI
+# will attempt to build every env against every Python version.
 matrix:
   include:
     - python: '2.6'
@@ -11,6 +13,8 @@ matrix:
       env: TOXENV=py35 VAULT_BRANCH=release
     - python: '3.5'
       env: TOXENV=py35 VAULT_BRANCH=head
+  # To mark some of the builds above as optional, we have to
+  # define them a second time in the allow_failures section below.
   allow_failures:
     - python: '2.6'
       env: TOXENV=py26 VAULT_BRANCH=release

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ python:
   - "2.6"
   - "2.7"
   - "3.5"
-install:
-  - scripts/install-vault-${VAULT_BRANCH}.sh
-  - pip install tox
 matrix:
   include:
     - python: '2.7'
@@ -19,6 +16,9 @@ matrix:
       env: TOXENV=py26 VAULT_BRANCH=release
     - python: '3.5'
       env: TOXENV=py35 VAULT_BRANCH=head
+install:
+  - scripts/install-vault-${VAULT_BRANCH}.sh
+  - pip install tox
 script:
   - export PATH=$HOME/bin:$PATH
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,18 @@ python:
 install:
   - scripts/install-vault-${VAULT_BRANCH}.sh
   - pip install tox
+env:  # https://docs.travis-ci.com/user/customizing-the-build/#Matching-Jobs-with-allow_failures
+matrix:
+  include:
+    - python: '2.7'
+      env: TOXENV=py27 VAULT_BRANCH=release
+    - python: '3.5'
+      env: TOXENV=py35 VAULT_BRANCH=release
+  allow_failures:
+    - python: '2.6'
+      env: TOXENV=py26 VAULT_BRANCH=release
+    - python: '3.5'
+      env: TOXENV=py35 VAULT_BRANCH=head
 script:
   - export PATH=$HOME/bin:$PATH
   - tox
-env:
-  - TOXENV=py26 VAULT_BRANCH=release
-  - TOXENV=py27 VAULT_BRANCH=release
-  - TOXENV=py35 VAULT_BRANCH=release
-  - TOXENV=py35 VAULT_BRANCH=head
-matrix:
-  allow_failures:
-    - env: TOXENV=py26 VAULT_BRANCH=release
-    - env: TOXENV=py35 VAULT_BRANCH=head


### PR DESCRIPTION
as per Travis CI doc: https://docs.travis-ci.com/user/languages/python/

Note that specifying multiple Python versions in `.travis.yml` also requires defining the build matrix explicitly, otherwise Travis CI will attempt to build every env declaration against every Python version. See: https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix

Closes https://github.com/ianunruh/hvac/issues/142.