### PR TITLE
Add auth_iam_aws() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ client.auth_app_id('MY_APP_ID', 'MY_USER_ID')
 # App Role
 client.auth_approle('MY_ROLE_ID', 'MY_SECRET_ID')
 
+# AWS
+client.auth_aws_iam('MY_AWS_ACCESS_KEY_ID', 'MY_AWS_SECRET_ACCESS_KEY')
+client.auth_aws_iam('MY_AWS_ACCESS_KEY_ID', 'MY_AWS_SECRET_ACCESS_KEY', 'MY_AWS_SESSION_TOKEN')
+client.auth_aws_iam('MY_AWS_ACCESS_KEY_ID', 'MY_AWS_SECRET_ACCESS_KEY', role='MY_ROLE')
+
+import boto3
+session = boto3.Session()
+credentials = session.get_credentials()
+client.auth_aws_iam(credentials.access_key, credentials.secret_key, credentials.token)
+
 # GitHub
 client.auth_github('MY_GITHUB_TOKEN')
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ client.auth_app_id('MY_APP_ID', 'MY_USER_ID')
 # App Role
 client.auth_approle('MY_ROLE_ID', 'MY_SECRET_ID')
 
-# AWS
+# AWS (IAM)
 client.auth_aws_iam('MY_AWS_ACCESS_KEY_ID', 'MY_AWS_SECRET_ACCESS_KEY')
 client.auth_aws_iam('MY_AWS_ACCESS_KEY_ID', 'MY_AWS_SECRET_ACCESS_KEY', 'MY_AWS_SESSION_TOKEN')
 client.auth_aws_iam('MY_AWS_ACCESS_KEY_ID', 'MY_AWS_SECRET_ACCESS_KEY', role='MY_ROLE')

--- a/hvac/aws_utils.py
+++ b/hvac/aws_utils.py
@@ -1,0 +1,42 @@
+import hmac
+from datetime import datetime
+from hashlib import sha256
+
+
+class SigV4Auth(object):
+    def __init__(self, access_key, secret_key, session_token=None):
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.session_token = session_token
+
+    def add_auth(self, request):
+        timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+        request.headers['X-Amz-Date'] = timestamp
+
+        if self.session_token:
+            request.headers['X-Amz-Security-Token'] = self.session_token
+
+        # https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+        canonical_headers = ''.join('{0}:{1}\n'.format(k.lower(), request.headers[k]) for k in sorted(request.headers))
+        signed_headers = ';'.join(k.lower() for k in sorted(request.headers))
+        payload_hash = sha256(request.body.encode('utf-8')).hexdigest()
+        canonical_request = '\n'.join([request.method, '/', '', canonical_headers, signed_headers, payload_hash])
+
+        # https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
+        algorithm = 'AWS4-HMAC-SHA256'
+        credential_scope = '/'.join([timestamp[0:8], 'us-east-1', 'sts', 'aws4_request'])
+        canonical_request_hash = sha256(canonical_request.encode('utf-8')).hexdigest()
+        string_to_sign = '\n'.join([algorithm, timestamp, credential_scope, canonical_request_hash])
+
+        # https://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
+        key = 'AWS4{0}'.format(self.secret_key).encode('utf-8')
+        key = hmac.new(key, timestamp[0:8].encode('utf-8'), sha256).digest()
+        key = hmac.new(key, 'us-east-1'.encode('utf-8'), sha256).digest()
+        key = hmac.new(key, 'sts'.encode('utf-8'), sha256).digest()
+        key = hmac.new(key, 'aws4_request'.encode('utf-8'), sha256).digest()
+        signature = hmac.new(key, string_to_sign.encode('utf-8'), sha256).hexdigest()
+
+        # https://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html
+        authorization = '{0} Credential={1}/{2}, SignedHeaders={3}, Signature={4}'.format(
+            algorithm, self.access_key, credential_scope, signed_headers, signature)
+        request.headers['Authorization'] = authorization

--- a/hvac/tests/test_unit.py
+++ b/hvac/tests/test_unit.py
@@ -12,7 +12,7 @@ from hvac import Client
 
 class UnitTest(TestCase):
 
-    @mock.patch('hvac.v1.datetime')
+    @mock.patch('hvac.aws_utils.datetime')
     @mock.patch('hvac.v1.Client.auth')
     def test_auth_aws_iam(self, auth_mock, datetime_mock):
         datetime_mock.utcnow.return_value = datetime(2015, 8, 30, 12, 36, 0)

--- a/hvac/tests/test_unit.py
+++ b/hvac/tests/test_unit.py
@@ -1,5 +1,9 @@
+import json
+from base64 import b64decode
+from datetime import datetime
 from unittest import TestCase
 
+import mock
 import requests_mock
 from nose.tools import *
 
@@ -7,6 +11,40 @@ from hvac import Client
 
 
 class UnitTest(TestCase):
+
+    @mock.patch('hvac.v1.datetime')
+    @mock.patch('hvac.v1.Client.auth')
+    def test_auth_aws_iam(self, auth_mock, datetime_mock):
+        datetime_mock.utcnow.return_value = datetime(2015, 8, 30, 12, 36, 0)
+
+        client = Client()
+        client.auth_aws_iam('AKIDEXAMPLE', 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY')
+
+        auth_mock.assert_called()
+        args, kwargs = auth_mock.call_args
+        actual_params = kwargs['json']
+
+        actual_iam_http_request_method = actual_params['iam_http_request_method']
+        self.assertEqual('POST', actual_iam_http_request_method)
+
+        actual_iam_request_url = b64decode(actual_params['iam_request_url']).decode('utf-8')
+        self.assertEqual('https://sts.amazonaws.com/', actual_iam_request_url)
+
+        expected_iam_request_headers = {
+            'Authorization': ['AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date, Signature=0268ea4a725deae1116f5228d6b177fb047f9f3a9e1c5fd4baa0dc1fbb0d1a99'],
+            'Content-Length': ['43'],
+            'Content-Type': ['application/x-www-form-urlencoded; charset=utf-8'],
+            'Host': ['sts.amazonaws.com'],
+            'X-Amz-Date': ['20150830T123600Z'],
+        }
+        actual_iam_request_headers = json.loads(b64decode(actual_params['iam_request_headers']))
+        self.assertEqual(expected_iam_request_headers, actual_iam_request_headers)
+
+        actual_iam_request_body = b64decode(actual_params['iam_request_body']).decode('utf-8')
+        self.assertEqual('Action=GetCallerIdentity&Version=2011-06-15', actual_iam_request_body)
+
+        actual_role = actual_params['role']
+        self.assertEqual('', actual_role)
 
     @requests_mock.Mocker()
     def test_auth_ec2(self, requests_mocker):

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import unicode_literals
 
+import hmac
 import json
+from base64 import b64encode
+from datetime import datetime
+from hashlib import sha256
 
 try:
     import hcl
@@ -597,6 +601,63 @@ class Client(object):
         params.update(kwargs)
 
         return self.auth('/v1/auth/{0}/login/{1}'.format(mount_point, username), json=params, use_token=use_token)
+
+    def auth_aws_iam(self, access_key, secret_key, session_token=None, header_value=None, mount_point='aws', role='', use_token=True):
+        """
+        POST /auth/<mount point>/login
+        """
+        timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+
+        method = 'POST'
+        url = 'https://sts.amazonaws.com/'
+        body = 'Action=GetCallerIdentity&Version=2011-06-15'
+        headers = {
+            'Content-Length': [str(len(body))],
+            'Content-Type': ['application/x-www-form-urlencoded; charset=utf-8'],
+            'Host': ['sts.amazonaws.com'],
+            'X-Amz-Date': [timestamp]
+        }
+
+        if session_token:
+            headers['X-Amz-Security-Token'] = [session_token]
+        if header_value:
+            headers['X-Vault-AWS-IAM-Server-ID'] = [header_value]
+
+        # https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+        canonical_headers = ''.join('{0}:{1}\n'.format(k.lower(), headers[k][0]) for k in sorted(headers))
+        signed_headers = ';'.join(k.lower() for k in sorted(headers))
+        payload_hash = sha256(body.encode('utf-8')).hexdigest()
+        canonical_request = '\n'.join([method, '/', '', canonical_headers, signed_headers, payload_hash])
+
+        # https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
+        algorithm = 'AWS4-HMAC-SHA256'
+        credential_scope = '/'.join([timestamp[0:8], 'us-east-1', 'sts', 'aws4_request'])
+        canonical_request_hash = sha256(canonical_request.encode('utf-8')).hexdigest()
+        string_to_sign = '\n'.join([algorithm, timestamp, credential_scope, canonical_request_hash])
+
+        # https://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
+        key = 'AWS4{0}'.format(secret_key).encode('utf-8')
+        key = hmac.new(key, timestamp[0:8].encode('utf-8'), sha256).digest()
+        key = hmac.new(key, 'us-east-1'.encode('utf-8'), sha256).digest()
+        key = hmac.new(key, 'sts'.encode('utf-8'), sha256).digest()
+        key = hmac.new(key, 'aws4_request'.encode('utf-8'), sha256).digest()
+        signature = hmac.new(key, string_to_sign.encode('utf-8'), sha256).hexdigest()
+
+        # https://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html
+        authorization = '{0} Credential={1}/{2}, SignedHeaders={3}, Signature={4}'.format(
+            algorithm, access_key, credential_scope, signed_headers, signature)
+        headers['Authorization'] = [authorization]
+
+        # https://github.com/hashicorp/vault/blob/master/builtin/credential/aws/cli.go
+        params = {
+            'iam_http_request_method': method,
+            'iam_request_url': b64encode(url.encode('utf-8')).decode('utf-8'),
+            'iam_request_headers': b64encode(json.dumps(headers).encode('utf-8')).decode('utf-8'),
+            'iam_request_body': b64encode(body.encode('utf-8')).decode('utf-8'),
+            'role': role,
+        }
+
+        return self.auth('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
 
     def auth_ec2(self, pkcs7, nonce=None, role=None, use_token=True, mount_point='aws-ec2'):
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 avakas
 coverage
+mock
 nose
 requests_mock
 semantic_version


### PR DESCRIPTION
Support the [AWS IAM auth method](aws). This includes an implementation
of AWS SigV4 authentication rather than adding additional dependencies
(e.g. boto3).

[aws]: https://www.vaultproject.io/docs/auth/aws.html#iam-auth-method