### PR TITLE
Add more methods for the userpass backend

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -276,13 +276,20 @@ class IntegrationTest(TestCase):
         if 'userpass/' not in self.client.list_auth_backends():
             self.client.enable_auth_backend('userpass')
 
+        # add some users and confirm that they show up in the list
         self.client.create_userpass('testuserone', 'testuseronepass', policies='not_root')
         self.client.create_userpass('testusertwo', 'testusertwopass', policies='not_root')
 
         user_list = self.client.list_userpass()
-
         assert 'testuserone' in user_list['data']['keys']
         assert 'testusertwo' in user_list['data']['keys']
+
+        # delete all the users and confirm that list_userpass() doesn't fail
+        for user in user_list['data']['keys']:
+            self.client.delete_userpass(user)
+
+        no_users_list = self.client.list_userpass()
+        assert no_users_list is None
 
     def test_delete_userpass(self):
         if 'userpass/' not in self.client.list_auth_backends():

--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -272,6 +272,18 @@ class IntegrationTest(TestCase):
         self.client.token = self.root_token()
         self.client.disable_auth_backend('userpass')
 
+    def test_list_userpass(self):
+        if 'userpass/' not in self.client.list_auth_backends():
+            self.client.enable_auth_backend('userpass')
+
+        self.client.create_userpass('testuserone', 'testuseronepass', policies='not_root')
+        self.client.create_userpass('testusertwo', 'testusertwopass', policies='not_root')
+
+        user_list = self.client.list_userpass()
+
+        assert 'testuserone' in user_list['data']['keys']
+        assert 'testusertwo' in user_list['data']['keys']
+
     def test_delete_userpass(self):
         if 'userpass/' not in self.client.list_auth_backends():
             self.client.enable_auth_backend('userpass')

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -626,6 +626,36 @@ class Client(object):
         except exceptions.InvalidPath:
             return None
 
+    def read_userpass(self, username, mount_point='userpass'):
+        """
+        GET /auth/<mount point>/users/<username>
+        """
+        return self._get('/v1/auth/{}/users/{}'.format(mount_point, username)).json()
+
+    def update_userpass_policies(self, username, policies, mount_point='userpass'):
+        """
+        POST /auth/<mount point>/users/<username>/policies
+        """
+        # userpass can have more than 1 policy. It is easier for the user to pass in the
+        # policies as a list so if they do, we need to convert to a , delimited string.
+        if isinstance(policies, (list, set, tuple)):
+            policies = ','.join(policies)
+
+        params = {
+            'policies': policies
+        }
+
+        return self._post('/v1/auth/{}/users/{}/policies'.format(mount_point, username), json=params)
+
+    def update_userpass_password(self, username, password, mount_point='userpass'):
+        """
+        POST /auth/<mount point>/users/<username>/password
+        """
+        params = {
+            'password': password
+        }
+        return self._post('/v1/auth/{}/users/{}/password'.format(mount_point, username), json=params)
+
     def delete_userpass(self, username, mount_point='userpass'):
         """
         DELETE /auth/<mount point>/users/<username>

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -617,6 +617,12 @@ class Client(object):
 
         return self._post('/v1/auth/{}/users/{}'.format(mount_point, username), json=params)
 
+    def list_userpass(self, mount_point='userpass'):
+        """
+        GET /auth/<mount point>/users?list=true
+        """
+        return self._get('/v1/auth/{}/users'.format(mount_point), params={'list': True}).json()
+
     def delete_userpass(self, username, mount_point='userpass'):
         """
         DELETE /auth/<mount point>/users/<username>

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -621,7 +621,10 @@ class Client(object):
         """
         GET /auth/<mount point>/users?list=true
         """
-        return self._get('/v1/auth/{}/users'.format(mount_point), params={'list': True}).json()
+        try:
+            return self._get('/v1/auth/{}/users'.format(mount_point), params={'list': True}).json()
+        except exceptions.InvalidPath:
+            return None
 
     def delete_userpass(self, username, mount_point='userpass'):
         """


### PR DESCRIPTION
There's a `create_userpass()` method and a `delete_userpass()` method, but no `list_userpass()`, `read_userpass()`, or policy/password update methods. _Until now._

Tests included.