### PR TITLE
client.write: kv uses POST instead of PUT

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -59,9 +59,9 @@ class Client(object):
 
     def write(self, path, wrap_ttl=None, **kwargs):
         """
-        PUT /<path>
+        POST /<path>
         """
-        response = self._put('/v1/{0}'.format(path), json=kwargs, wrap_ttl=wrap_ttl)
+        response = self._post('/v1/{0}'.format(path), json=kwargs, wrap_ttl=wrap_ttl)
 
         if response.status_code == 200:
             return response.json()


### PR DESCRIPTION
Vault 0.10 introduced a breaking change in the KV secrets enging HTTP
API. It requires HTTP POST instead of HTTP PUT, backwards compatible.

KV v2:
https://www.vaultproject.io/api/secret/kv/kv-v2.html#create-update-secret

KV v1:
https://www.vaultproject.io/api/secret/kv/kv-v1.html#create-update-secret