### PR TITLE
fix: Re-remove auth_ec2 double json parsing

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -597,7 +597,7 @@ class Client(object):
         if role:
             params['role'] = role
 
-        return self.auth('/v1/auth/aws-ec2/login', json=params, use_token=use_token).json()
+        return self.auth('/v1/auth/aws-ec2/login', json=params, use_token=use_token)
 
     def create_userpass(self, username, password, policies, mount_point='userpass', **kwargs):
         """


### PR DESCRIPTION
The double parsing seemed to have been re-introduced from #61.

Related: #76 

This prevents the following error from being thrown:
```
Traceback (most recent call last):
...
    return self.auth('/v1/auth/aws-ec2/login', json=params, use_token=use_token).json()
AttributeError: 'dict' object has no attribute 'json'

```

It does appear that #61 was merged in before #76 but looking at git blame the latest changes only reflect from #61. Maybe there was a rebase gone wrong along the way.