### PR TITLE
docs: Include command needed to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ print(client.is_sealed()) # => True
 Integration tests will automatically start a Vault server in the background. Just make sure
 the latest `vault` binary is available in your `PATH`.
 
-1. [Install Vault](https://vaultproject.io/docs/install/index.html)
+1. [Install Vault](https://vaultproject.io/docs/install/index.html) or execute `VAULT_BRANCH=release scripts/install-vault-release.sh`
 2. [Install Tox](http://tox.readthedocs.org/en/latest/install.html)
+3. Run tests: `make test`
 
 ## Contributing
 


### PR DESCRIPTION
This updates the README on how to execute tests.

It wasn't clear that running `make test` was the magic, as simply running `tox` you get an error, as
```
Processing ./.tox/dist/hvac-0.5.0.zip
    Complete output from command python setup.py egg_info:
    /tmp/pip-req-build-0m769lg4/version is missing
```

Mainly this happens because setup is expecting `hvac/version` to be present.