### PR TITLE
Add Methods for Auth Backend Tuning

### DIFF
--- a/hvac/tests/test_auth_methods.py
+++ b/hvac/tests/test_auth_methods.py
@@ -11,6 +11,7 @@ class TestAuthMethods(TestCase):
     @requests_mock.Mocker()
     def test_tune_auth_backend(self, requests_mocker):
         expected_status_code = 204
+        test_backend_type = 'approle'
         test_mount_point = 'approle-test'
         test_description = 'this is a test description'
         requests_mocker.register_uri(
@@ -20,6 +21,7 @@ class TestAuthMethods(TestCase):
         )
         client = Client()
         actual_response = client.tune_auth_backend(
+            backend_type=test_backend_type,
             mount_point=test_mount_point,
             description=test_description,
         )
@@ -40,6 +42,7 @@ class TestAuthMethods(TestCase):
     @requests_mock.Mocker()
     def test_get_auth_backend_tuning(self, requests_mocker):
         expected_status_code = 200
+        test_backend_type = 'approle'
         test_mount_point = 'approle-test'
         mock_response = {
             'max_lease_ttl': 12345678,
@@ -66,6 +69,7 @@ class TestAuthMethods(TestCase):
         )
         client = Client()
         actual_response = client.get_auth_backend_tuning(
+            backend_type=test_backend_type,
             mount_point=test_mount_point,
         )
 
@@ -73,5 +77,3 @@ class TestAuthMethods(TestCase):
             first=mock_response,
             second=actual_response,
         )
-
-

--- a/hvac/tests/test_auth_methods.py
+++ b/hvac/tests/test_auth_methods.py
@@ -1,0 +1,77 @@
+from unittest import TestCase
+
+import requests_mock
+
+from hvac import Client
+
+
+class TestAuthMethods(TestCase):
+    """Tests for methods related to Vault sys/auth routes."""
+
+    @requests_mock.Mocker()
+    def test_tune_auth_backend(self, requests_mocker):
+        expected_status_code = 204
+        test_mount_point = 'approle-test'
+        test_description = 'this is a test description'
+        requests_mocker.register_uri(
+            method='POST',
+            url='http://localhost:8200/v1/sys/auth/{0}/tune'.format(test_mount_point),
+            status_code=expected_status_code,
+        )
+        client = Client()
+        actual_response = client.tune_auth_backend(
+            mount_point=test_mount_point,
+            description=test_description,
+        )
+
+        self.assertEqual(
+            first=expected_status_code,
+            second=actual_response.status_code,
+        )
+
+        actual_request_params = requests_mocker.request_history[0].json()
+
+        # Ensure we sent through an optional tune parameter as expected
+        self.assertEqual(
+            first=test_description,
+            second=actual_request_params['description'],
+        )
+
+    @requests_mock.Mocker()
+    def test_get_auth_backend_tuning(self, requests_mocker):
+        expected_status_code = 200
+        test_mount_point = 'approle-test'
+        mock_response = {
+            'max_lease_ttl': 12345678,
+            'lease_id': '',
+            'force_no_cache': False,
+            'warnings': None,
+            'data': {
+                'force_no_cache': False,
+                'default_lease_ttl': 2764800,
+                'max_lease_ttl': 12345678
+            },
+            'wrap_info': None,
+            'auth': None,
+            'lease_duration': 0,
+            'request_id': '673f2336-3235-b988-2194-c68261a02bfe',
+            'default_lease_ttl': 2764800,
+            'renewable': False
+        }
+        requests_mocker.register_uri(
+            method='GET',
+            url='http://localhost:8200/v1/sys/auth/{0}/tune'.format(test_mount_point),
+            status_code=expected_status_code,
+            json=mock_response
+        )
+        client = Client()
+        actual_response = client.get_auth_backend_tuning(
+            mount_point=test_mount_point,
+        )
+
+        self.assertEqual(
+            first=mock_response,
+            second=actual_response,
+        )
+
+

--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -1057,6 +1057,7 @@ class IntegrationTest(TestCase):
         self.client.disable_auth_backend(mount_point=test_mount_point)
 
     def test_tune_auth_backend(self):
+        test_backend_type = 'approle'
         test_mount_point = 'tune-approle'
         test_description = 'this is a test auth backend'
         test_max_lease_ttl = 12345678
@@ -1069,6 +1070,7 @@ class IntegrationTest(TestCase):
 
         expected_status_code = 204
         response = self.client.tune_auth_backend(
+            backend_type=test_backend_type,
             mount_point=test_mount_point,
             description=test_description,
             max_lease_ttl=test_max_lease_ttl,
@@ -1079,6 +1081,7 @@ class IntegrationTest(TestCase):
         )
 
         response = self.client.get_auth_backend_tuning(
+            backend_type=test_backend_type,
             mount_point=test_mount_point
         )
 

--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -1055,3 +1055,36 @@ class IntegrationTest(TestCase):
         # Reset test state.
         self.client.token = self.root_token()
         self.client.disable_auth_backend(mount_point=test_mount_point)
+
+    def test_tune_auth_backend(self):
+        test_mount_point = 'tune-approle'
+        test_description = 'this is a test auth backend'
+        test_max_lease_ttl = 12345678
+        if '{0}/'.format(test_mount_point) in self.client.list_auth_backends():
+            self.client.disable_auth_backend(test_mount_point)
+        self.client.enable_auth_backend(
+            backend_type='approle',
+            mount_point=test_mount_point
+        )
+
+        expected_status_code = 204
+        response = self.client.tune_auth_backend(
+            mount_point=test_mount_point,
+            description=test_description,
+            max_lease_ttl=test_max_lease_ttl,
+        )
+        self.assertEqual(
+            first=expected_status_code,
+            second=response.status_code,
+        )
+
+        response = self.client.get_auth_backend_tuning(
+            mount_point=test_mount_point
+        )
+
+        self.assertEqual(
+            first=test_max_lease_ttl,
+            second=response['data']['max_lease_ttl']
+        )
+
+        self.client.disable_auth_backend(mount_point=test_mount_point)

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -936,6 +936,51 @@ class Client(object):
 
         self._post('/v1/sys/auth/{0}'.format(mount_point), json=params)
 
+    def tune_auth_backend(self, mount_point=None, default_lease_ttl=None, max_lease_ttl=None, description=None,
+                          audit_non_hmac_request_keys=None, audit_non_hmac_response_keys=None, listing_visibility=None,
+                          passthrough_request_headers=None):
+        """
+        POST /sys/auth/<mount point>/tune
+        :param mount_point: str, The path the associated auth backend is mounted under.
+        :param description: str, Specifies the description of the mount. This overrides the current stored value, if any.
+        :param default_lease_ttl: int,
+        :param max_lease_ttl: int,
+        :param audit_non_hmac_request_keys: list, Specifies the comma-separated list of keys that will not be HMAC'd by
+        audit devices in the request data object.
+        :param audit_non_hmac_response_keys: list, Specifies the comma-separated list of keys that will not be HMAC'd
+        by audit devices in the response data object.
+        :param listing_visibility: str, Speficies whether to show this mount in the UI-specific listing endpoint.
+        Valid values are "unauth" or "".
+        :param passthrough_request_headers: list, Comma-separated list of headers to whitelist and pass from the request
+        to the backend.
+        :return: dict, The JSON response from Vault
+        """
+        # All parameters are optional for this method. Until/unless we include input validation, we simply loop over the
+        # parameters and add which parameters are set.
+        optional_parameters = [
+            'default_lease_ttl',
+            'max_lease_ttl',
+            'description',
+            'audit_non_hmac_request_keys',
+            'audit_non_hmac_response_keys',
+            'listing_visibility',
+            'passthrough_request_headers',
+        ]
+        params = {}
+        for optional_parameter in optional_parameters:
+            if locals().get(optional_parameter) is not None:
+                params[optional_parameter] = locals().get(optional_parameter)
+        return self._post('/v1/sys/auth/{0}/tune'.format(mount_point), json=params)
+
+    def get_auth_backend_tuning(self, mount_point=None):
+        """
+        GET /sys/auth/<mount point>/tune
+        :param mount_point: str, The path the associated auth backend is mounted under.
+        :return: dict, The JSON response from Vault
+        """
+
+        return self._get('/v1/sys/auth/{0}/tune'.format(mount_point)).json()
+
     def disable_auth_backend(self, mount_point):
         """
         DELETE /sys/auth/<mount point>

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -936,11 +936,12 @@ class Client(object):
 
         self._post('/v1/sys/auth/{0}'.format(mount_point), json=params)
 
-    def tune_auth_backend(self, mount_point=None, default_lease_ttl=None, max_lease_ttl=None, description=None,
+    def tune_auth_backend(self, backend_type, mount_point=None, default_lease_ttl=None, max_lease_ttl=None, description=None,
                           audit_non_hmac_request_keys=None, audit_non_hmac_response_keys=None, listing_visibility=None,
                           passthrough_request_headers=None):
         """
         POST /sys/auth/<mount point>/tune
+        :param backend_type: str, Name of the auth backend to modify (e.g., token, approle, etc.)
         :param mount_point: str, The path the associated auth backend is mounted under.
         :param description: str, Specifies the description of the mount. This overrides the current stored value, if any.
         :param default_lease_ttl: int,
@@ -955,6 +956,8 @@ class Client(object):
         to the backend.
         :return: dict, The JSON response from Vault
         """
+        if not mount_point:
+            mount_point = backend_type
         # All parameters are optional for this method. Until/unless we include input validation, we simply loop over the
         # parameters and add which parameters are set.
         optional_parameters = [
@@ -972,12 +975,15 @@ class Client(object):
                 params[optional_parameter] = locals().get(optional_parameter)
         return self._post('/v1/sys/auth/{0}/tune'.format(mount_point), json=params)
 
-    def get_auth_backend_tuning(self, mount_point=None):
+    def get_auth_backend_tuning(self, backend_type, mount_point=None):
         """
         GET /sys/auth/<mount point>/tune
+        :param backend_type: str, Name of the auth backend to modify (e.g., token, approle, etc.)
         :param mount_point: str, The path the associated auth backend is mounted under.
         :return: dict, The JSON response from Vault
         """
+        if not mount_point:
+            mount_point = backend_type
 
         return self._get('/v1/sys/auth/{0}/tune'.format(mount_point)).json()
 


### PR DESCRIPTION
Addresses https://github.com/ianunruh/hvac/issues/192.

Adds two methods to handle GETs and POSTs requests to `/v1/sys/auth/<mount_point>/tune`.