### PR TITLE
Always Specify auth_type In create_ec2_role

### DIFF
--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -811,6 +811,7 @@ class Client(object):
         """
         params = {
             'role': role,
+            'auth_type': 'ec2',
             'disallow_reauthentication': disallow_reauthentication,
             'allow_instance_migration': allow_instance_migration
         }


### PR DESCRIPTION
Since Vault v0.7.1, the aws-ec2 and aws-iam Auth backends have been unified under one "aws" auth backend. This overlap requires an "auth_type" parameter to be specified in some cases and in particular is necessary with newer Vault versions + our create_ec2_role() method + a subset of parameters in this method that apply to both EC2 and IAM authentication.