### PR TITLE
update enable_secret_backend function to support kv version 2

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -1279,3 +1279,15 @@ class IntegrationTest(TestCase):
         )
 
         self.client.disable_auth_backend(mount_point=test_mount_point)
+
+    def test_kv2_secret_backend(self):
+        if 'test/' in self.client.list_secret_backends():
+            self.client.disable_secret_backend('test')
+        self.client.enable_secret_backend('kv', mount_point='test', options={'version': '2'})
+
+        secret_backends = self.client.list_secret_backends()
+
+        assert 'test/' in secret_backends
+        self.assertDictEqual(secret_backends['test/']['options'], {'version': '2'})
+
+        self.client.disable_secret_backend('test')

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -310,7 +310,7 @@ class Client(object):
         """
         return self._get('/v1/sys/mounts').json()
 
-    def enable_secret_backend(self, backend_type, description=None, mount_point=None, config=None):
+    def enable_secret_backend(self, backend_type, description=None, mount_point=None, config=None, options=None):
         """
         POST /sys/auth/<mount point>
         """
@@ -321,6 +321,7 @@ class Client(object):
             'type': backend_type,
             'description': description,
             'config': config,
+            'options': options,
         }
 
         self._post('/v1/sys/mounts/{0}'.format(mount_point), json=params)


### PR DESCRIPTION
Hi there,

to enable K/V-Store v2 (https://www.vaultproject.io/docs/secrets/kv/kv-v2.html) there need to be options with version set.

So then you can use it like
```python
result = vault.enable_secret_backend('kv', mount_point='secrets', options={'version': '2'})
```

Thanks
Sebastian

Please have a look and let me know if you need more information / updates to the code