### PR TITLE
add read_lease

### DIFF
--- a/hvac/tests/test_integration.py
+++ b/hvac/tests/test_integration.py
@@ -1566,3 +1566,23 @@ class IntegrationTest(TestCase):
 
         # Reset integration test state
         self.client.disable_auth_backend(mount_point=test_mount_point)
+
+    def test_read_lease(self):
+        # Set up a test pki backend and issue a cert against some role so we.
+        util.configure_test_pki(client=self.client)
+        pki_issue_response = self.client.write(
+            path='pki/issue/my-role',
+            common_name='test.hvac.com',
+        )
+
+        # Read the lease of our test cert that was just issued.
+        read_lease_response = self.client.read_lease(pki_issue_response['lease_id'])
+
+        # Validate we received the expected lease ID back in our response.
+        self.assertEquals(
+            first=pki_issue_response['lease_id'],
+            second=read_lease_response['data']['id'],
+        )
+
+        # Reset integration test state.
+        util.disable_test_pki(client=self.client)

--- a/hvac/tests/test_system_backend_methods.py
+++ b/hvac/tests/test_system_backend_methods.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+
+import requests_mock
+from parameterized import parameterized
+
+from hvac import Client
+
+
+class TestSystemBackendMethods(TestCase):
+    """Unit tests providing coverage for Vault system backend-related methods in the hvac Client class."""
+
+    @parameterized.expand([
+        ("pki lease ID", 'pki/issue/my-role/12c7e036-b59e-5e79-3370-03826fc6f34b'),
+    ])
+    @requests_mock.Mocker()
+    def test_read_lease(self, test_label, test_lease_id, requests_mocker):
+        test_path = 'http://localhost:8200/v1/sys/leases/lookup'
+        mock_response = {
+            'lease_id': '',
+            'request_id': '34cd8d7c-e59f-7166-49c9-1e65149ff676',
+            'auth': None,
+            'data': {
+                'issue_time': '2018-07-15T08:35:34.775859245-05:00',
+                'renewable': False,
+                'id': test_lease_id,
+                'ttl': 259199,
+                'expire_time': '2018-07-18T08:35:34.00004241-05:00',
+                'last_renewal': None
+            },
+            'warnings': None,
+            'wrap_info': None,
+            'lease_duration': 0,
+            'renewable': False
+        }
+        requests_mocker.register_uri(
+            method='PUT',
+            url=test_path,
+            json=mock_response,
+        )
+        client = Client()
+        response = client.read_lease(
+            lease_id=test_lease_id,
+        )
+        self.assertEquals(
+            first=mock_response,
+            second=response,
+        )

--- a/hvac/tests/util.py
+++ b/hvac/tests/util.py
@@ -61,3 +61,56 @@ def match_version(spec):
     version = Version(VERSION_REGEX.match(output).group(1))
 
     return Spec(spec).match(version)
+
+
+def configure_test_pki(client, common_name='hvac.com', role_name='my-role', mount_point='pki'):
+    """Helper function to configure a pki backend for integration tests that need to work with lease IDs.
+
+    :param client: Authenticated hvac.v1.Client instance.
+    :type client: hvac.v1.Client
+    :param common_name: Common name to configure in the pki backend
+    :type common_name: str.
+    :param role_name: Name of the test role to configure.
+    :type role_name: str.
+    :param mount_point: The path the pki backend is mounted under.
+    :type mount_point: str.
+    :return: Nothing.
+    :rtype: None.
+    """
+    if '{path}/'.format(path=mount_point) in client.list_secret_backends():
+        client.disable_secret_backend(mount_point)
+
+    client.enable_secret_backend(backend_type='pki', mount_point=mount_point)
+
+    client.write(
+        path='{path}/root/generate/internal'.format(path=mount_point),
+        common_name=common_name,
+        ttl='8760h',
+    )
+    client.write(
+        path='{path}/config/urls'.format(path=mount_point),
+        issuing_certificates="http://127.0.0.1:8200/v1/pki/ca",
+        crl_distribution_points="http://127.0.0.1:8200/v1/pki/crl",
+    )
+    client.write(
+        path='{path}/roles/{name}'.format(path=mount_point, name=role_name),
+        allowed_domains=common_name,
+        allow_subdomains=True,
+        generate_lease=True,
+        max_ttl='72h',
+    )
+
+
+def disable_test_pki(client, mount_point='pki'):
+    """
+
+    :param client: Authenticated hvac.v1.Client instance.
+    :type client: hvac.v1.Client
+    :param mount_point: The path the pki backend is mounted under.
+    :type mount_point: str.
+    :return: Nothing.
+    :rtype: None.
+    """
+
+    # Reset integration test state
+    client.disable_secret_backend(mount_point)

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -272,10 +272,12 @@ class Client(object):
         return self._get('/v1/sys/leader').json()
 
     def read_lease(self, lease_id):
-        """
-        PUT /sys/leases/lookup
-        :param lease_id: str, specifies the ID of the lease to lookup.
-        :return dict, parsed JSON response from the leases PUT request
+        """PUT /sys/leases/lookup
+
+        :param lease_id: Specifies the ID of the lease to lookup.
+        :type lease_id: str.
+        :return: Parsed JSON response from the leases PUT request
+        :rtype: dict.
         """
         params = {
             'lease_id': lease_id

--- a/hvac/v1/__init__.py
+++ b/hvac/v1/__init__.py
@@ -271,6 +271,17 @@ class Client(object):
         """
         return self._get('/v1/sys/leader').json()
 
+    def read_lease(self, lease_id):
+        """
+        PUT /sys/leases/lookup
+        :param lease_id: str, specifies the ID of the lease to lookup.
+        :return dict, parsed JSON response from the leases PUT request
+        """
+        params = {
+            'lease_id': lease_id
+        }
+        return self._put('/v1/sys/leases/lookup', json=params).json()
+
     def renew_secret(self, lease_id, increment=None):
         """
         PUT /sys/leases/renew


### PR DESCRIPTION
This PR will add the 'read_lease' function so you can check how long it takes before you lease expires: 

https://www.vaultproject.io/api/system/leases.html#read-lease

