### PR TITLE
Remove deploy stage from travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ matrix:
   - python: '2.7'
     env: TOXENV=py27-flake8 VAULT_BRANCH=release
   - python: '3.6'
-    env: TOXENV=py36 VAULT_BRANCH=release RELEASE=yes
+    env: TOXENV=py36 VAULT_BRANCH=release
   - python: '3.6'
-    env: TOXENV=py36-flake8 VAULT_BRANCH=release RELEASE=yes
+    env: TOXENV=py36-flake8 VAULT_BRANCH=release
   - python: '3.6'
     env: TOXENV=py36 VAULT_BRANCH=head
   allow_failures:
@@ -21,15 +21,3 @@ install:
 - pip install tox
 script:
 - export PATH=$HOME/bin:$PATH
-- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then make package ; else make test ; fi
-deploy:
-  skip_cleanup: true
-  provider: pypi
-  user: otakup0pe
-  on:
-    tags: true
-    all_branches: true
-    repo: ianunruh/hvac
-    condition: $RELEASE == "yes"
-  password:
-    secure: MDKviWOPUrxuBAClPjh1WH/FtBj9PIDBZ1LLQFWgBsvQaauCpqN6p9M6ysWT/20Ou3AePjFJJ2KA0oYU7UW+qmXqCGyvYBiIzMXvDcjhBK60UOhFtzMDq3rEwVDCIWRfk1zCxpQYiw2Eq2T/E/wdtfUqwVVWRCL4tdCTXv48EuA=


### PR DESCRIPTION
Dropping this stage from the config as I'd prefer staging new releases to https://test.pypi.org/project/hvac/ to verify things and manually deploy to pypi.org for the time being.